### PR TITLE
Fix lien date de remise

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Projet 1 - Préparez vos placements financiers
 
 <!--- Changer la date de remise en modifiant le URL--->
-#### :alarm_clock: [Date de remise le dimanche 3 octobre à 23h59](https://www.timeanddate.com/countdown/generic?iso=20200928T2359&p0=165&msg=Remise&font=cursive&csz=1#)
+#### :alarm_clock: [Date de remise le dimanche 3 octobre à 23h59](https://www.timeanddate.com/countdown/generic?iso=20211003T2359&p0=165&msg=Remise&font=cursive&csz=1#)
 
 ## Objectif
-Concevoir et implémenter un programme permettant de calculer le rendement de différents investissements selon différentes situations. 
+Concevoir et implémenter un programme permettant de calculer le rendement de différents investissements selon différentes situations.
 
 ## Partie 1 : Interet simple /5 pts
-À faire : compléter le fichier `partie_1.py` 
+À faire : compléter le fichier `partie_1.py`
 
 on place un capital de 8 000 $ pendant 72 jours au taux annuel de 6.5%. Calculer l’intérêt et la valeur acquise à l’issue du placement. On utilise la formule suivante:
 <img src="https://render.githubusercontent.com/render/math?math=I=Ctn">.
@@ -20,7 +20,7 @@ on place un capital de 8 000 $ pendant 72 jours au taux annuel de 6.5%. Calculer
 Enfin:  **Valeur acquise = Capital + Intérêts**
 
 
-Exemple d'affichage : 
+Exemple d'affichage :
 
 ![Formules de section](data/affichage_partie1.png)
 
@@ -35,7 +35,7 @@ On possède un capital de 2600$. Votre banquier vous propose deux types de place
 
 i) Calculez le montant de votre capital avec le premier placement au 100ème jour de l'année
 
-ii) Calculez le montant de votre capital avec le deuxième placement au 300ème jour de l'année 
+ii) Calculez le montant de votre capital avec le deuxième placement au 300ème jour de l'année
 
 iii) Au bout de combien de jours le deuxième placement vous rapportera plus que le premier ? (Question à faire avec une boucle)
 
@@ -44,7 +44,7 @@ Remarque : La formule pour calculer la valeur de votre capital est :
 <strong>C = capital_initial + capital_initial*(taux/365)*nb_jours</strong>
 
 
-Exemple d'affichage : 
+Exemple d'affichage :
 
 ![Formules de section](data/affichage_partie2.png)
 
@@ -58,7 +58,7 @@ Soit le capital initial **C<sub>0</sub>** = 300 000$ et le capital placé récup
 Calculer  **C<sub>20</sub>** le capital placé pendant 20 années avec un taux d'intérêt de 8%.
 
 
-Exemple d'affichage : 
+Exemple d'affichage :
 
 ![Formules de section](data/affichage_partie3.png)
 


### PR DESCRIPTION
Le lien de la date de remise date de l'année dernière. Cette PR modifie l'URL du lien pour que ça pointe vers la date de remise de cette année.

Les espaces vides à la fin des lignes ont aussi été supprimés.